### PR TITLE
Visualize Num_cases_per_country

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,11 +57,6 @@
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.6.0.tgz",
       "integrity": "sha512-amuilneCf7q5A/jDUE3ml83c9NjW/3DzIqiBDFIKZcraD0JSKbetkEQa5s57Z6QY7jxcequXgoL9CKJUY1xZ5A=="
     },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
     "@npmcli/move-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
@@ -2222,27 +2217,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
-      }
-    },
-    "google-map-react": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.1.9.tgz",
-      "integrity": "sha512-//Pa0o6sdspU2H0ehVztSDQSnYYeV6TY4Z6ftty34yiCJYLliOzeq17dA9uFkyUFdL+XwbTU6e9mfs+bjBMIzw==",
-      "requires": {
-        "@googlemaps/js-api-loader": "^1.7.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "eventemitter3": "^4.0.4",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@googlemaps/js-api-loader": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.11.1.tgz",
-          "integrity": "sha512-2ug4uBu0onRXTAo7Yxkay5N7pdNIz3XpTElMTLdCtEfQDxikbjeR6GS8atVhblX+ubFBNlXvDzz7VtuXv0vMRQ==",
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@react-google-maps/api": "^1.13.0",
     "axios": "^0.21.0",
     "bootstrap": "^4.5.3",
-    "google-map-react": "^2.1.9",
     "google-maps-react": "^2.0.6",
     "i18next": "^19.8.4",
     "react-bootstrap-table-next": "^4.0.3",

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Header } from 'semantic-ui-react';
 import { Map, GoogleApiWrapper, IMapProps, Circle, InfoWindow } from 'google-maps-react';
-// import GoogleMapReact from 'google-map-react';
 import '../major_elements/index.js';
 
 import * as cst from "../utils/konst";
@@ -78,6 +77,7 @@ export class MapContainer extends React.Component<IMapProps, MapContainerState> 
             center= {ctryinfo[country]['center']}
             radius= {ctryinfo[country]['num_cases'] * 30}
           />
+          
         )
       } else continue;
     }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -3,14 +3,14 @@ import Axios, { AxiosInstance, AxiosResponse, CancelToken } from "axios";
 import * as cst from "./konst";
 
 
-// const baseURL = "http://58.145.3.213:8000/api";
-const baseURL = "http://127.0.0.1:8000/api";
+const baseURL = "http://58.145.3.213:8000/api";
+// const baseURL = "http://127.0.0.1:8000/api";
 
 
 const instance: AxiosInstance = Axios.create({
     baseURL,
-    // timeout: 100_000,
-    timeout: 1000_000,
+    timeout: 100_000,
+    // timeout: 1000_000,
 });
 
 


### PR DESCRIPTION
국가별 케이스가 뜨긴 하는데, 케이스의 수가 국가마다 천차만별이라 원 크기의 차이가 큽니다. 큰 건 너무 크고 작은건 너무 작아서 밸런스 조절이 안 돼요... 작은 원에 맞춰서 키우면 큰 원이 너무 커져서 어느 나라에서 나온건지 파악이 불가능합니다. 큰 원에 맞추면 작은 원이 점 마냥 작아지구요..

![image](https://user-images.githubusercontent.com/50168998/100802786-5f4ea000-346d-11eb-9ade-97a3b7c8e19c.png)

이런 식인데요, 제가 생각한 해결 방법은 두가지입니다.
```
1. 기준치를 넘어선 case들은 루트 등의 조치를 취해 밸런스를 조절한다. 
- 물론 원래 작은 case들보다는 훨씬 크게 조정하긴 할건데, 이럴 경우 raw data가 왜곡되는 것이기 때문에 약간 꺼려집니다.
2. 지도를 한국 쪽으로 줌인해서 한국 주변 데이터에 집중하도록 한다. 
- 지도가 확대된 상태이기 때문에 작은 원도 어느정도 크게 볼 수 있습니다. 하지만 줌아웃하면 결과는 지금과 같습니다.
```
어떤 방법으로 해결하는게 좋을까요?


+ 각 Circle들에 관한 InfoWindow는 아직 구현하지 못했습니다..리스트로 전달하니까 막히는 부분이 있는데ㅠㅠㅠㅠ 오늘 완성해볼게요.. 늦어서 죄송합니다ㅜㅜ
+ 동해가 일본해로 떠서ㅡㅡ;; index.html 수정해서 동해로 뜨도록 변경했습니다!
+ 왜인지 계속 이전 커밋들이 남아있고 지저분하네요.. 혼자서 합치기엔 과정이 조금 겁나서 추후에 시도해보겠습니다...ㅠㅠ
